### PR TITLE
Add generated .proto files to package dist dir

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ import { mkdir, readdir, readFile, writeFile } from "fs/promises";
 import { join, basename, sep } from "path";
 import { format, Options } from "prettier";
 
+import writeProtobuf from "./writeProtobuf";
+
 const LICENSE = `// This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/`;
@@ -47,6 +49,7 @@ async function main() {
   await mkdir(distDir, { recursive: true });
   await writeFile(libFile, libOutput);
   await writeFile(declFile, declOutput);
+  await writeProtobuf(join(distDir, "proto"), definitions);
 }
 
 async function getMsgFiles(dir: string): Promise<string[]> {

--- a/src/writeProtobuf.ts
+++ b/src/writeProtobuf.ts
@@ -1,0 +1,99 @@
+import { RosMsgDefinition } from "@foxglove/rosmsg";
+import fs from "fs/promises";
+import path from "path";
+
+const BUILTINS_PROTO = `syntax = "proto3";
+
+package ros.builtins;
+
+message Time {
+  fixed32 sec = 1;
+  fixed32 nsec = 2;
+}
+
+message Duration {
+  fixed32 sec = 1;
+  fixed32 nsec = 2;
+}
+`;
+
+const BUILTIN_TYPE_MAP = new Map([
+  ["time", "ros.builtins.Time"],
+  ["duration", "ros.builtins.Duration"],
+  ["uint8", "int32"],
+  ["uint16", "int32"],
+  ["int8", "sint32"],
+  ["int16", "sint32"],
+  ["float32", "float"],
+  ["float64", "double"],
+]);
+
+export default async function writeProtobuf(
+  protoPath: string,
+  definitions: Record<string, RosMsgDefinition>,
+): Promise<void> {
+  const entries = Object.entries(definitions).sort(([a], [b]) => a.localeCompare(b));
+
+  for (const [typeName, def] of entries) {
+    const nameParts = typeName.split("/");
+    if (nameParts.length !== 2) {
+      throw new Error(`Invalid name ${typeName}`);
+    }
+    const packageName = nameParts[0]!;
+    const msgName = nameParts[1]!;
+
+    const imports = new Set<string>();
+
+    const fields: string[] = [];
+    let fieldNumber = 1;
+    for (const field of def.definitions) {
+      if (field.isConstant === true) {
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        fields.push(`// ${field.type} ${field.name} = ${field.valueText ?? field.value ?? ""}`);
+        continue;
+      }
+      const qualifiers = [];
+      if (field.type === "uint8" && field.isArray === true) {
+        qualifiers.push("bytes");
+      } else {
+        if (field.isArray === true) {
+          qualifiers.push("repeated");
+        }
+        if (field.isComplex === true) {
+          qualifiers.push(`ros.${field.type.replace("/", ".")}`);
+          imports.add(field.type);
+        } else if (BUILTIN_TYPE_MAP.has(field.type)) {
+          if (field.type === "time" || field.type === "duration") {
+            imports.add("builtins");
+          }
+          qualifiers.push(BUILTIN_TYPE_MAP.get(field.type)!);
+        } else {
+          qualifiers.push(field.type);
+        }
+      }
+      fields.push(`${qualifiers.join(" ")} ${field.name} = ${fieldNumber++};`);
+    }
+
+    const output = `// Generated from ${typeName}.msg
+
+syntax = "proto3";
+
+${Array.from(imports)
+  .sort()
+  .map((name) => `import "ros/${name}.proto";`)
+  .join("\n")}
+package ros.${packageName};
+
+message ${msgName} {
+  ${fields.join("\n  ")}
+}
+`;
+
+    const packageDir = path.join(protoPath, "ros", packageName);
+    await fs.mkdir(packageDir, { recursive: true });
+    await fs.writeFile(path.join(packageDir, `${msgName}.proto`), output);
+  }
+
+  await fs.mkdir(path.join(protoPath, "ros"), { recursive: true });
+  await fs.writeFile(path.join(protoPath, "ros", `builtins.proto`), BUILTINS_PROTO);
+}

--- a/src/writeProtobuf.ts
+++ b/src/writeProtobuf.ts
@@ -32,9 +32,7 @@ export default async function writeProtobuf(
   protoPath: string,
   definitions: Record<string, RosMsgDefinition>,
 ): Promise<void> {
-  const entries = Object.entries(definitions).sort(([a], [b]) => a.localeCompare(b));
-
-  for (const [typeName, def] of entries) {
+  for (const [typeName, def] of Object.entries(definitions)) {
     const nameParts = typeName.split("/");
     if (nameParts.length !== 2) {
       throw new Error(`Invalid name ${typeName}`);


### PR DESCRIPTION
Example output for PointCloud2:

```proto
// Generated from sensor_msgs/PointCloud2.msg

syntax = "proto3";

import "ros/sensor_msgs/PointField.proto";
import "ros/std_msgs/Header.proto";
package ros.sensor_msgs;

message PointCloud2 {
  ros.std_msgs.Header header = 1;
  uint32 height = 2;
  uint32 width = 3;
  repeated ros.sensor_msgs.PointField fields = 4;
  bool is_bigendian = 5;
  uint32 point_step = 6;
  uint32 row_step = 7;
  bytes data = 8;
  bool is_dense = 9;
}
```