### PR TITLE
Fix: Exports and export assignments are not permitted in module augmentations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,20 +81,18 @@ module.exports = { definitions };
 function generateDefinitions(definitions: Record<string, RosMsgDefinition>): string {
   const entries = Object.keys(definitions)
     .sort()
-    .map((key) => `    "${key}": RosMsgDefinition;`)
+    .map((key) => `  "${key}": RosMsgDefinition;`)
     .join("\n");
   return `${LICENSE}
 
 import { RosMsgDefinition } from "@foxglove/rosmsg";
 
-declare module "@foxglove/rosmsg-msgs-common" {
-  type RosMsgCommonDefinitions = {
+export type RosMsgCommonDefinitions = {
 ${entries}
-  };
+};
 
-  const definitions: RosMsgCommonDefinitions;
-  export { definitions };
-}
+declare const definitions: RosMsgCommonDefinitions;
+export { definitions };
 `;
 }
 


### PR DESCRIPTION
Using this package via typescript, I was getting this error:

```ts
> tsc -b tsconfig.json
../../node_modules/.registry.npmjs.org/@foxglove/rosmsg-msgs-common/1.1.0/node_modules/@foxglove/rosmsg-msgs-common/dist/index.d.ts:128:3 - error TS2666: Exports and export assignments are not permitted in module augmentations.
128 export { definitions };
~~~~~~

Found 1 error.
```

I found that the generated .d.ts had this line, which doesn't feel quite right:

```ts
declare module "@foxglove/rosmsg-msgs-common" {
  ...
}
```

I *think* that the module declaration syntax is meant for when one module wants to modify another. Removing the module declaration and just using plain export directives resolved the compiler error for us.

I'm not exactly a .d.ts expert, so I may be missing something here... but if you don't have any objections to trimming the .d.ts file down to just the plain exports, I think this PR will resolve the issue for others going forward. 