### PR TITLE
Feat: add esm module export

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/foxglove/rosmsg-msgs-common",
   "main": "dist/index.js",
+  "module": "dist/index.esm.js",
   "typings": "dist/index.d.ts",
   "files": [
     "dist",


### PR DESCRIPTION
### Public-Facing Changes

Export an esm module via "module" property in package.json

### Description

Add support for ESM generated library, so some esm friendly build tools such as `Vite` can benefit from it since browser also use this library. 

Although, `vite` can use pre-optimize, commonjs plugin, but provide esm module also provide treeshaking when esm import this library.
