### PR TITLE
CI: bump node to v20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 20.x
           registry-url: https://registry.npmjs.org
           cache: yarn
 


### PR DESCRIPTION
### Changelog
None

### Description
Same reasoning as https://github.com/foxglove/rosmsg/pull/51